### PR TITLE
Add Navigation Between Folders

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import './App.css'
-import { FileData } from './mocks/filedata/filedata';
+import { FileData, Folder } from './mocks/filedata/filedata';
 import { GetData } from './mocks/filedata';
 import FileExplorer from './components/FileExplorer/FileExplorer';
 
@@ -9,11 +9,20 @@ function App() {
     const [isLoading, setIsLoading] = useState<boolean>(true);
     const [hasError, setHasError] = useState<boolean>(false);
 
-    const [selectedFolder, setSelectedFolder] = useState<string>();
+    const [selectedFolder, setSelectedFolder] = useState<string>("");
 
     const filePathText = useMemo<string>(() => {
         return selectedFolder ? `/ ${selectedFolder}` : ''
     }, [selectedFolder])
+
+    const filteredData = useMemo(() => {
+        const selectedFolderData = data?.find((entry) => entry.name === selectedFolder) as Folder;
+        if (selectedFolderData) {
+            return selectedFolderData.files
+        }
+
+        return data
+    }, [data, selectedFolder])
 
     useEffect(() => {   
         GetData.then((response) => {
@@ -27,15 +36,24 @@ function App() {
 
     return (
         <div className="text-left">
+            {filePathText && (
+                <button 
+                    className="text-sm"
+                    onClick={() => setSelectedFolder("")}
+                >
+                    Go Back
+                </button>
+            )}
             <header className="font-bold my-4">
                 <h1 className="text-2xl">
                     Files {filePathText}
                 </h1>
             </header>
             <FileExplorer 
-                data={data} 
+                data={filteredData} 
                 isLoading={isLoading} 
-                hasError={hasError} 
+                hasError={hasError}
+                setSelectedFolder={setSelectedFolder}
             />  
         </div>
     )

--- a/src/components/FileExplorer/FileEntry.test.tsx
+++ b/src/components/FileExplorer/FileEntry.test.tsx
@@ -34,7 +34,7 @@ afterEach(() => {
 })
 
 test('renders FileEntry with test File', async () => {
-    lastMount = render(<FileEntry entry={testFile} />);
+    lastMount = render(<FileEntry entry={testFile} setSelectedFolder={() => {}} />);
 
     expect(screen.getByText(testFile.name)).toBeTruthy();
     expect(screen.getByText(`.${testFile.type}`)).toBeTruthy();
@@ -44,7 +44,7 @@ test('renders FileEntry with test File', async () => {
 })
 
 test('renders FileEntry with test Folder', async () => {
-    lastMount = render(<FileEntry entry={testFolder} />);
+    lastMount = render(<FileEntry entry={testFolder} setSelectedFolder={() => {}} />);
 
     expect(screen.getByText(testFolder.name)).toBeTruthy();
     expect(screen.getByTestId("file-entry").getAttribute("disabled")).toBeNull();

--- a/src/components/FileExplorer/FileEntry.tsx
+++ b/src/components/FileExplorer/FileEntry.tsx
@@ -1,11 +1,13 @@
+import { Dispatch, SetStateAction } from "react"
 import { FileEntry as FileEntryType, Folder } from "../../mocks/filedata/filedata"
 import { FolderIcon } from "../Icons"
 
 interface FileEntryInterface {
     entry: FileEntryType | Folder
+    setSelectedFolder: Dispatch<SetStateAction<string>>
 }
 
-export const FileEntry = ({entry} : FileEntryInterface) => {
+export const FileEntry = ({entry, setSelectedFolder} : FileEntryInterface) => {
     const isFolder = entry.type.toLowerCase() === "folder"
 
     const fileType = isFolder ? (
@@ -27,7 +29,8 @@ export const FileEntry = ({entry} : FileEntryInterface) => {
     return (
         <button 
             data-testid="file-entry"
-            className="text-left min-h-12 flex justify-center flex-col disabled:bg-transparent disabled:border-0" 
+            className="text-left min-h-12 flex justify-center flex-col disabled:bg-transparent disabled:border-0"
+            onClick={() => setSelectedFolder(entry.name)}
             disabled={!isFolder}
         >
             <p className="mb-1 flex">

--- a/src/components/FileExplorer/FileExplorer.test.tsx
+++ b/src/components/FileExplorer/FileExplorer.test.tsx
@@ -1,0 +1,62 @@
+import { test, afterEach, expect } from "vitest";
+import { render, screen, RenderResult } from '@testing-library/react'
+import filedata from "../../mocks/filedata/filedata.json";
+import FileExplorer from "./FileExplorer";
+
+let lastMount: RenderResult;
+
+afterEach(() => {
+    if (lastMount) lastMount.unmount();
+})
+
+test('does not show loaded data until isLoading is false', async () => {
+    lastMount = render(
+        <FileExplorer 
+            data={filedata} 
+            hasError={false} 
+            isLoading={true} 
+            setSelectedFolder={() => {}} 
+        />
+    );
+
+    expect(screen.getByTestId("loading")).toBeTruthy();
+})
+
+test('renders FileExplorer if data exists', async () => {
+    lastMount = render(
+        <FileExplorer 
+            data={filedata} 
+            hasError={false} 
+            isLoading={false} 
+            setSelectedFolder={() => {}} 
+        />
+    );
+
+    expect(screen.getAllByTestId("file-entry").length).toEqual(5);
+})
+
+test('shows message in FileExplorer if there is no data', async () => {
+    lastMount = render(
+        <FileExplorer 
+            data={[]} 
+            hasError={false} 
+            isLoading={false} 
+            setSelectedFolder={() => {}} 
+        />
+    );
+
+    expect(screen.getByTestId("empty-data")).toBeTruthy();
+})
+
+test('shows error message in FileExplorer', async () => {
+    lastMount = render(
+        <FileExplorer 
+            data={[]} 
+            hasError={true} 
+            isLoading={false} 
+            setSelectedFolder={() => {}} 
+        />
+    );
+
+    expect(screen.getByTestId("error-loading")).toBeTruthy();
+})

--- a/src/components/FileExplorer/FileExplorer.tsx
+++ b/src/components/FileExplorer/FileExplorer.tsx
@@ -1,3 +1,4 @@
+import { Dispatch, SetStateAction } from "react"
 import { FileData } from "../../mocks/filedata/filedata"
 import { LoadingSpinner } from "../Icons"
 import { FileEntry } from "./FileEntry"
@@ -5,11 +6,12 @@ import { FileEntry } from "./FileEntry"
 interface FileExplorerInterface {
     isLoading: boolean
     hasError: boolean
+    setSelectedFolder: Dispatch<SetStateAction<string>>
     data?: FileData
 }
 
-const FileExplorer = ({isLoading, data, hasError}: FileExplorerInterface) => {
-    if (hasError) {
+const FileExplorer = ({...props}: FileExplorerInterface) => {
+    if (props.hasError) {
         return (
             <p data-testid="error-loading">
                 <strong>Error:</strong> Exception when loading file data.
@@ -17,17 +19,23 @@ const FileExplorer = ({isLoading, data, hasError}: FileExplorerInterface) => {
         )
     }
 
-    if (isLoading) {
+    if (props.isLoading) {
         return <LoadingSpinner />
     }
 
-    if (!data) {
-        return <p data-testid="empty-data">No data to show</p>
+    if (!props.data || props.data.length === 0) {
+        return <p data-testid="empty-data">No files found</p>
     }
 
     return (
         <div className="flex flex-col gap-2">
-            {data.map((entry) => <FileEntry key={entry.name.replace(/ /g, '')} entry={entry} />)}
+            {props.data.map((entry) => (
+                <FileEntry
+                    key={entry.name.replace(/ /g, '')}
+                    setSelectedFolder={props.setSelectedFolder}
+                    entry={entry}
+                />
+            ))}
         </div>
     )
 

--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -12,5 +12,7 @@ export const LoadingSpinner = () => (
 )
 
 export const FolderIcon = () => (
-    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path></svg>
+    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path>
+    </svg>
 )


### PR DESCRIPTION
## Purpose
Allow a user to open a folder to see it’s contents

## Design / Screenshots
![Screenshot 2025-01-21 225257](https://github.com/user-attachments/assets/8e747e77-555d-4718-859b-0565c6fba1ac)

## Approach
Utilize `useMemo` to apply a filter on the `data` object if `selectedFolder` has been populated.